### PR TITLE
Add docker support for arm64/aarch64 systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 FROM ubuntu:23.04
 
-ENV LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH
-ENV LIBRARY_PATH=/usr/lib64:$LIBRARY_PATH
+#use --build-arg LIB_DIR=/usr/lib for arm64 cpus
+ARG LIB_DIR=/usr/lib64
+
+ENV LD_LIBRARY_PATH=$LIB_DIR:$LD_LIBRARY_PATH
+ENV LIBRARY_PATH=$LIB_DIR:$LIBRARY_PATH
 
 RUN apt-get update -y
 RUN apt-get install -y libcurl4-openssl-dev wget libnss3 nss-plugin-pem ca-certificates
-# RUN strings /lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX_3.4
+# RUN strings /lib/$(arch)-linux-gnu/libstdc++.so.6 | grep GLIBCXX_3.4
 
-RUN wget https://github.com/lwthiker/curl-impersonate/releases/download/v0.5.4/libcurl-impersonate-v0.5.4.x86_64-linux-gnu.tar.gz
-RUN mv libcurl-impersonate-v0.5.4.x86_64-linux-gnu.tar.gz /usr/lib64
-RUN cd /usr/lib64 && tar -xvf libcurl-impersonate-v0.5.4.x86_64-linux-gnu.tar.gz && rm -rf libcurl-impersonate-v0.5.4.x86_64-linux-gnu.tar.gz
+RUN wget https://github.com/lwthiker/curl-impersonate/releases/download/v0.5.4/libcurl-impersonate-v0.5.4.$(arch)-linux-gnu.tar.gz
+RUN mv libcurl-impersonate-v0.5.4.$(arch)-linux-gnu.tar.gz $LIB_DIR
+RUN cd $LIB_DIR && tar -xvf libcurl-impersonate-v0.5.4.$(arch)-linux-gnu.tar.gz && rm -rf libcurl-impersonate-v0.5.4.$(arch)-linux-gnu.tar.gz
 
 WORKDIR /app
 


### PR DESCRIPTION
Needs build argument passed in docker build command only for arm64 cpus, otherwise, the command remains same.
docker build . --build-arg LIB_DIR=/usr/lib